### PR TITLE
Add privacy policy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Privacy Policy for OakLife Digital Inc.">
+    <title>Privacy Policy - OakLife Digital Inc.</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.8;
+            color: #333;
+            background: #f5f5f7;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        h1 {
+            color: #1d1d1f;
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            font-weight: 700;
+        }
+
+        .effective-date {
+            color: #666;
+            font-size: 1rem;
+            margin-bottom: 20px;
+        }
+
+        .content {
+            background: white;
+            border-radius: 12px;
+            padding: 40px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .intro {
+            margin-bottom: 30px;
+            color: #1d1d1f;
+        }
+
+        h2 {
+            color: #1d1d1f;
+            font-size: 1.5rem;
+            margin-top: 30px;
+            margin-bottom: 15px;
+            font-weight: 600;
+        }
+
+        p {
+            margin-bottom: 15px;
+            color: #444;
+        }
+
+        ul {
+            margin-left: 20px;
+            margin-bottom: 15px;
+        }
+
+        li {
+            margin-bottom: 8px;
+            color: #444;
+        }
+
+        strong {
+            color: #1d1d1f;
+        }
+
+        a {
+            color: #0071e3;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        footer {
+            text-align: center;
+            margin-top: 40px;
+            padding: 20px;
+            color: #666;
+        }
+
+        footer a {
+            color: #0071e3;
+        }
+
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+
+            .content {
+                padding: 30px 20px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Privacy Policy</h1>
+            <p class="effective-date"><strong>Effective Date:</strong> October 2025</p>
+        </header>
+
+        <div class="content">
+            <p class="intro">
+                OakLife Digital Inc. ("we", "our", or "us") values your privacy. This Privacy Policy explains how we collect, use, and protect information through our mobile app ("App").
+            </p>
+
+            <h2>1. Information We Collect</h2>
+            <p>When you use our App via Apple Sign-In, we collect:</p>
+            <ul>
+                <li><strong>Name:</strong> The name associated with your Apple account.</li>
+                <li><strong>Email Address:</strong> The email associated with your Apple account.</li>
+            </ul>
+
+            <h2>2. How We Use Your Information</h2>
+            <p>We use the collected information to:</p>
+            <ul>
+                <li>Provide and personalize our App experience.</li>
+                <li>Communicate with you regarding your account or App updates.</li>
+                <li>Ensure security and prevent unauthorized use of the App.</li>
+            </ul>
+
+            <h2>3. How We Share Your Information</h2>
+            <p>We do not sell or rent your personal information. We may share your information only:</p>
+            <ul>
+                <li>With service providers who assist us in operating the App, under strict confidentiality agreements.</li>
+                <li>If required by law or to protect our legal rights.</li>
+            </ul>
+
+            <h2>4. Data Retention</h2>
+            <p>We retain your information only as long as necessary to provide the App services and comply with legal obligations.</p>
+
+            <h2>5. User Rights</h2>
+            <p>You can:</p>
+            <ul>
+                <li>Access, update, or correct your information through your Apple account.</li>
+                <li>Request deletion of your data by contacting us at <a href="mailto:support@oaklife.com">support@oaklife.com</a>.</li>
+            </ul>
+
+            <h2>6. Security</h2>
+            <p>We implement reasonable technical and administrative measures to protect your data. However, no method of transmission over the Internet or electronic storage is 100% secure.</p>
+
+            <h2>7. Updates to This Privacy Policy</h2>
+            <p>We may update this Privacy Policy from time to time. The "Effective Date" will indicate the latest version.</p>
+
+            <h2>8. Contact Us</h2>
+            <p>If you have questions about this Privacy Policy or your data, please contact us at:</p>
+            <ul>
+                <li><strong>Email:</strong> <a href="mailto:support@oaklife.com">support@oaklife.com</a></li>
+                <li><strong>Website:</strong> <a href="https://www.oaklife.com">https://www.oaklife.com</a></li>
+            </ul>
+        </div>
+
+        <footer>
+            <p>&copy; 2025 OakLife Digital Inc. All rights reserved.</p>
+            <p style="margin-top: 10px;">
+                <a href="index.html">Back to Home</a>
+            </p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add privacy policy page for OakLife Digital Inc.
- Covers data collection via Apple Sign-In (name and email)
- Includes information on data usage, sharing, retention, and user rights
- Professional styling matching the site aesthetic

## Test plan
- [ ] Verify page displays correctly on desktop and mobile
- [ ] Check all links work properly
- [ ] Review privacy policy content for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)